### PR TITLE
Improve HCPSS domain detection

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,7 +1,12 @@
 <?php
 session_start();
 if ($_SESSION != null) {
-    if (strpos($_SESSION["email"], "inst.hcpss") !== false) {
+    if ((strpos($_SESSION["email"], "@") !== false)
+        && (substr(
+            $_SESSION["email"],
+            strrpos($_SESSION["email"], "@")
+        ) === "@inst.hcpss.org")
+    ) {
         // user is hcpss student
         header("LOCATION: http://ahsraidertime.com/student");
         exit();
@@ -37,7 +42,7 @@ if ($_SESSION != null) {
 }
 </style>
 </head>
-<!--_____________________________________________________________________________________________________________-->
+<!--_________________________________________________________________________-->
 
 <body>
 
@@ -48,7 +53,10 @@ if ($_SESSION != null) {
 	<script>
 		function onSignIn(googleUser) {
 			var profile = googleUser.getBasicProfile();
-			if (profile.getEmail().indexOf("hcpss.org") == -1) {
+      var eml = profile.getEmail();
+			if ((eml.indexOf("@") === -1)
+        || !["@hcpss.org", "@inst.hcpss.org"].includes(eml.substring(eml.lastIndexOf("@")))
+      ) {
 				var auth2 = gapi.auth2.getAuthInstance();
 				auth2.signOut();
 				window.alert("Only HCPSS google accounts allowed");
@@ -60,14 +68,14 @@ if ($_SESSION != null) {
 		}
 
 	</script>
-	<!--______________________________________________________________________________________________________-->
+	<!--_______________________________________________________________________-->
 	<div class="center">
       <p>Atholton Raider Time</p>
 		<div class="g-signin2" data-onsuccess="onSignIn" -theme="dark" data-width="190" data-height="70"></div>
   	</div>
-	
-  	
-      
+
+
+
 	  <?php include("menu.html");?>
 
 	<div class="footer">

--- a/login.php
+++ b/login.php
@@ -20,7 +20,9 @@ error_reporting(E_ALL);
 function get_var($var)
 {
     $id = $_POST["id"]; // id from google
-    $id_token = file("https://www.googleapis.com/oauth2/v3/tokeninfo?id_token=" . $id); // decrypted id
+    $id_token = file(
+      "https://www.googleapis.com/oauth2/v3/tokeninfo?id_token=" . $id
+    ); // decrypted id
     foreach ($id_token as $part) {
         // part is a factor of the user such as name or email
         // remove unecessary charcters
@@ -57,16 +59,21 @@ if ($conn->connect_error) {
 // TODO check if id is expired
 
 
-if (strpos($email, 'hcpss.org') !== false) {
+$emldom = (strpos($email, "@") !== false)
+    ? substr($email, strrpos($email, "@")) : "";
+
+if ((strcmp($emldom, "@hcpss.org") === 0)
+    || (strcmp($emldom, "@inst.hcpss.org") === 0)
+) {
 	// user is hcpss
     session_start();
     $_SESSION["name"] = preg_replace('/[^A-Za-z0-9\- ]/', '', $name);
     $_SESSION["email"] = $email;
     // $_SESSION["exp"] = $exp; // when to auto logout
     // $_SESSION["img"] = $img_url;
-	
-	
-    if (strpos($email, '@inst.hcpss.org') !== false) {
+
+
+    if (strcmp($emldom, "@inst.hcpss.org") === 0) {
         // user is student
         // get firstname and lastname
         $_SESSION["fname"] = preg_replace('/[^A-Za-z0-9\- ]/', '', trim(get_var("given_name")));
@@ -76,9 +83,9 @@ if (strpos($email, 'hcpss.org') !== false) {
 
 		echo $_SESSION["name"];
 		echo phpinfo();
-		session_write_close(); session_regenerate_id(true); 
-		
-		
+		session_write_close(); session_regenerate_id(true);
+
+
 		exit();
     } else {
         // user is not student
@@ -95,7 +102,7 @@ if (strpos($email, 'hcpss.org') !== false) {
         if (in_array($name, $administrators)) {
             header("LOCATION: http://ahsraidertime.com/administrator/");
             exit();
-        } elseif (strpos($email, '@hcpss.org') !== false) {
+        } elseif (strcmp($emldom, "hcpss.org") === 0) {
             // teacher
             header("LOCATION: http://ahsraidertime.com/teacher/");
             exit();

--- a/menu.php
+++ b/menu.php
@@ -28,18 +28,18 @@ session_start();
    if ($result->num_rows > 0) {
        $row = $result->fetch_assoc();
        //$haveNumber = strcmp($row["NOTIFICATION"] ,"") != 0;
-       
+
 ?>
 
 <html>
-    
+
     <body>
         <nav role="navigation">
-  
+
 	        <div id="menuToggle">
 
 		    <input type="checkbox" />
-		
+
 		    <span></span>
 		    <span></span>
 		    <span></span>
@@ -49,15 +49,23 @@ session_start();
 		            <a href="http://ahsraidertime.com"><li>Home</li></a>
 		            <a href="http://ahsraidertime.com/about/"><li>FAQ'S</li></a>
 		            <a href="http://ahsraidertime.com/announcements/"><li>Announcements</li></a>
-                    <?php 
-                        $sql = "SELECT * FROM `administrators` WHERE `EMAIL` = '$email'";
-                        $results = $conn->query($sql);
-                        if($results->num_rows > 0) {
-                            echo "<a href=http://ahsraidertime.com/dummyStudentLogin.php><li>Test Account</li></a>";
+                    <?php
+                        $emldom = (strpos($email, "@") !== false)
+                            ? substr($email, strrpos($email, "@")) : "";
+                        if ((strcmp($emldom, "hcpss.org")
+                            || strcmp($emldom, "@inst.hcpss.org"))
+                            && ctype_alnum(substr($email, 0, strrpos($email, "@")))
+                        ) {
+                            // email is not a SQL injection
+                            $sql = "SELECT * FROM `administrators` WHERE `EMAIL` = '$email'";
+                            $results = $conn->query($sql);
+                            if($results->num_rows > 0) {
+                                echo "<a href=http://ahsraidertime.com/dummyStudentLogin.php><li>Test Account</li></a>";
+                            }
                         }
-                        ?>
+                    ?>
 		        </ul>
-	
+
 	        </div>
         </nav>
     </body>

--- a/menu.php
+++ b/menu.php
@@ -52,9 +52,11 @@ session_start();
                     <?php
                         $emldom = (strpos($email, "@") !== false)
                             ? substr($email, strrpos($email, "@")) : "";
+	                $allowed = array(".", "-", "_");
+	                $emlloc = substr($email, 0, strrpos($email, "@"));
                         if ((strcmp($emldom, "hcpss.org")
                             || strcmp($emldom, "@inst.hcpss.org"))
-                            && ctype_alnum(substr($email, 0, strrpos($email, "@")))
+                            && ctype_alnum(str_replace($allowed, "", $emlloc))
                         ) {
                             // email is not a SQL injection
                             $sql = "SELECT * FROM `administrators` WHERE `EMAIL` = '$email'";


### PR DESCRIPTION
Before this patch, HCPSS domains were detected by checking if the email contained "hcpss.org", which allowed emails like "hcpss.org@gmail.com" to cause errors. Similar emails would be able to act as SQL injections. This patch allows domains to be properly detected in both PHP and JS and removes a potential SQL injection. I also modified some code to comply with CS standards.